### PR TITLE
Save configuration files in a more human readable format.

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,7 +216,7 @@ func main() {
 func saveConfig(config Config) {
 	Rules.mu.RLock() //Lock to read the rules
 	config.Rules = Rules.Rules
-	b, _ := json.Marshal(config)
+	b, _ := json.MarshalIndent(config, "", "\t")
 	Rules.mu.RUnlock()
 
 	err := os.WriteFile(ConfigFileName, b, 0644)


### PR DESCRIPTION
When using only a couple rules, saving the file without any formatting is fine.
However when using need a few rules things start to get ugly and hard to maintain.
This change saves the file using TABs to indent the configuration JSON.